### PR TITLE
Add `reraise` flag to expose non-0 status code

### DIFF
--- a/roam_to_git/__main__.py
+++ b/roam_to_git/__main__.py
@@ -16,7 +16,7 @@ from roam_to_git.fs import reset_git_directory, unzip_markdown_archive, \
 from roam_to_git.scrapping import patch_pyppeteer, scrap, Config
 
 
-@logger.catch()
+@logger.catch(reraise=True)
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("directory", default=None, nargs="?",


### PR DESCRIPTION
Related to, but does not address root cause of https://github.com/MatthieuBizien/roam-to-git/issues/18.

I noticed that when the commit stage of the [main.yml](https://github.com/MatthieuBizien/roam-to-git-demo/blob/master/.github/workflows/main.yml) action fails, it still proceeds and commits the empty directory, clearing it.

As a temporary solution, I changed the logger to reraise any encountered exceptions, so Actions knows to abort the run with:

`##[error]Process completed with exit code 1.`
