### PR TITLE
Fix export dropdown bug when there is more than one option

### DIFF
--- a/roam_to_git/scrapping.py
+++ b/roam_to_git/scrapping.py
@@ -148,7 +148,8 @@ async def _download_rr_archive(document: Page,
         logger.debug("Changing output type to {}", output_type)
         await button.click()
         await asyncio.sleep(config.sleep_duration)
-        output_type_elem, = await document.querySelectorAll(".bp3-text-overflow-ellipsis")
+        output_type_elems = await document.querySelectorAll(".bp3-text-overflow-ellipsis")
+        output_type_elem, = [e for e in output_type_elems if await get_text(document, e) == output_type]
         await output_type_elem.click()
 
         # defensive check


### PR DESCRIPTION

<img width="311" alt="Screen Shot 2020-10-20 at 5 00 48 PM" src="https://user-images.githubusercontent.com/6791023/96651849-5198ed00-12fb-11eb-9bde-d4688cfe7a3f.png">

Recently, a new format was added as an option for exporting.
This breaks the current script with the following error:

```    
output_type_elem, = await document.querySelectorAll(".bp3-text-overflow-ellipsis")
                              │        └ <function Page.querySelectorAll at 0x101e759d0>
                              └ <pyppeteer.page.Page object at 0x101eb6ee0>

ValueError: too many values to unpack (expected 1)
```
 


Instead of assuming there is exactly one non-default export format option, expect a list and find the right one