### PR TITLE
Select the correct class when changing download type

### DIFF
--- a/roam_to_git/scrapping.py
+++ b/roam_to_git/scrapping.py
@@ -148,7 +148,7 @@ async def _download_rr_archive(document: Page,
         logger.debug("Changing output type to {}", output_type)
         await button.click()
         await asyncio.sleep(config.sleep_duration)
-        output_type_elem, = await document.querySelectorAll(".bp3-text-overflow-ellipsis")
+        output_type_elem = await document.querySelector(".bp3-text-overflow-ellipsis")
         await output_type_elem.click()
 
         # defensive check


### PR DESCRIPTION
This fixes #60 
Somehow Roam has changed CSS class so that only one matching ".bp3-text-overflow-ellipsis".