### PR TITLE
Add EDN Support

### DIFF
--- a/roam_to_git/__main__.py
+++ b/roam_to_git/__main__.py
@@ -12,7 +12,7 @@ from loguru import logger
 
 from roam_to_git.formatter import read_markdown_directory, format_markdown
 from roam_to_git.fs import reset_git_directory, unzip_markdown_archive, \
-    unzip_and_save_json_archive, commit_git_directory, push_git_repository, save_markdowns
+    unzip_and_save_json_archive, unzip_and_save_edn_archive, commit_git_directory, push_git_repository, save_markdowns
 from roam_to_git.scrapping import patch_pyppeteer, scrap, Config
 
 
@@ -65,15 +65,18 @@ def main():
 
     reset_git_directory(git_path / "formatted")
     if not args.skip_fetch:
+        reset_git_directory(git_path / "edn")
         reset_git_directory(git_path / "json")
         reset_git_directory(git_path / "markdown")
 
         with tempfile.TemporaryDirectory() as markdown_zip_path, \
-                tempfile.TemporaryDirectory() as json_zip_path:
+                tempfile.TemporaryDirectory() as json_zip_path, \
+                tempfile.TemporaryDirectory() as edn_zip_path:
             markdown_zip_path = Path(markdown_zip_path)
             json_zip_path = Path(json_zip_path)
+            edn_zip_path = Path(edn_zip_path)
 
-            scrap(markdown_zip_path, json_zip_path, config)
+            scrap(markdown_zip_path, json_zip_path, edn_zip_path, config)
             if config.debug:
                 logger.debug("waiting for the download...")
                 time.sleep(20)
@@ -81,6 +84,7 @@ def main():
             raws = unzip_markdown_archive(markdown_zip_path)
             save_markdowns(git_path / "markdown", raws)
             unzip_and_save_json_archive(json_zip_path, git_path / "json")
+            unzip_and_save_edn_archive(edn_zip_path, git_path / "edn")
 
     formatted = format_markdown(read_markdown_directory(git_path / "markdown"))
     save_markdowns(git_path / "formatted", formatted)

--- a/roam_to_git/__main__.py
+++ b/roam_to_git/__main__.py
@@ -11,9 +11,23 @@ from dotenv import load_dotenv
 from loguru import logger
 
 from roam_to_git.formatter import read_markdown_directory, format_markdown
-from roam_to_git.fs import reset_git_directory, unzip_markdown_archive, \
-    unzip_and_save_json_archive, unzip_and_save_edn_archive, commit_git_directory, push_git_repository, save_markdowns
-from roam_to_git.scrapping import patch_pyppeteer, scrap, Config
+from roam_to_git.fs import reset_git_directory, save_files, unzip_and_save_archive, \
+    commit_git_directory, push_git_repository
+from roam_to_git.scrapping import patch_pyppeteer, scrap, Config, ROAM_FORMATS
+
+CUSTOM_FORMATS = ("formatted",)
+ALL_FORMATS = ROAM_FORMATS + CUSTOM_FORMATS
+DEFAULT_FORMATS = ROAM_FORMATS[:2] + CUSTOM_FORMATS  # exclude EDN from default formats
+
+
+# https://stackoverflow.com/a/41153081/3262054
+# Extend action is only available in Python 3.8+
+class ExtendAction(argparse.Action):
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        items = getattr(namespace, self.dest) or []
+        items.extend(values)
+        setattr(namespace, self.dest, items)
 
 
 @logger.catch(reraise=True)
@@ -32,12 +46,16 @@ def main():
                              "git-related action.")
     parser.add_argument("--skip-push", action="store_true",
                         help="Don't git push after commit.")
-    parser.add_argument("--skip-fetch", action="store_true",
-                        help="Do not download the data from Roam, just update the formatting.")
     parser.add_argument("--sleep-duration", type=float, default=2.,
                         help="Duration to wait for the interface. We wait 100x that duration for"
                              "Roam to load. Increase it if Roam servers are slow, but be careful"
                              "with the free tier of Github Actions.")
+    parser.add_argument("--formats", "-f", action=ExtendAction, nargs="+", type=str,
+                        help="Which formats to save. Options include json, markdown, formatted, "
+                             "and edn. Note that if only formatted is specified, the markdown "
+                             "directory will be converted to a formatted directory skipping "
+                             "fetching entirely. Also note that if jet is installed, the edn "
+                             "output will be pretty printed allowing for cleaner git diffs.")
     args = parser.parse_args()
 
     patch_pyppeteer()
@@ -63,31 +81,34 @@ def main():
         repo = git.Repo(git_path)
         assert not repo.bare  # Fail fast if it's not a repo
 
-    reset_git_directory(git_path / "formatted")
-    if not args.skip_fetch:
-        reset_git_directory(git_path / "edn")
-        reset_git_directory(git_path / "json")
-        reset_git_directory(git_path / "markdown")
+    if args.formats is None or len(args.formats) == 0:
+        args.formats = DEFAULT_FORMATS
 
-        with tempfile.TemporaryDirectory() as markdown_zip_path, \
-                tempfile.TemporaryDirectory() as json_zip_path, \
-                tempfile.TemporaryDirectory() as edn_zip_path:
-            markdown_zip_path = Path(markdown_zip_path)
-            json_zip_path = Path(json_zip_path)
-            edn_zip_path = Path(edn_zip_path)
+    if any(f not in ALL_FORMATS for f in args.formats):
+        logger.error("The format values must be one of {}.", ALL_FORMATS)
+        sys.exit(1)
 
-            scrap(markdown_zip_path, json_zip_path, edn_zip_path, config)
+    # reset all directories to be modified
+    for f in args.formats:
+        reset_git_directory(git_path / f)
+
+    # check if we need to fetch a format from roam
+    roam_formats = [f for f in args.formats if f in ROAM_FORMATS]
+    if len(roam_formats) > 0:
+        with tempfile.TemporaryDirectory() as root_zip_path:
+            root_zip_path = Path(root_zip_path)
+            scrap(root_zip_path, roam_formats, config)
             if config.debug:
                 logger.debug("waiting for the download...")
                 time.sleep(20)
                 return
-            raws = unzip_markdown_archive(markdown_zip_path)
-            save_markdowns(git_path / "markdown", raws)
-            unzip_and_save_json_archive(json_zip_path, git_path / "json")
-            unzip_and_save_edn_archive(edn_zip_path, git_path / "edn")
+            # Unzip and save all the downloaded files.
+            for f in roam_formats:
+                unzip_and_save_archive(f, root_zip_path / f, git_path / f)
 
-    formatted = format_markdown(read_markdown_directory(git_path / "markdown"))
-    save_markdowns(git_path / "formatted", formatted)
+    if "formatted" in args.formats:
+        formatted = format_markdown(read_markdown_directory(git_path / "markdown"))
+        save_files("formatted", git_path / "formatted", formatted)
 
     if repo is not None:
         commit_git_directory(repo)

--- a/roam_to_git/fs.py
+++ b/roam_to_git/fs.py
@@ -73,6 +73,19 @@ def unzip_and_save_json_archive(zip_dir_path: Path, directory: Path):
                 json.dump(content, f, sort_keys=True, indent=2, ensure_ascii=True)
 
 
+def unzip_and_save_edn_archive(zip_dir_path: Path, directory: Path):
+    logger.debug("Saving edn to {}", directory)
+    directory.mkdir(exist_ok=True)
+    zip_path = get_zip_path(zip_dir_path)
+    with zipfile.ZipFile(zip_path) as zip_file:
+        files = list(zip_file.namelist())
+        for file in files:
+            assert file.endswith(".edn")
+            content = zip_file.read(file)
+            with open(directory / file, "wb") as f:
+                f.write(content)
+
+
 def commit_git_directory(repo: git.Repo):
     """Add an automatic commit in a git directory if it has changed, and push it"""
     if not repo.is_dirty() and not repo.untracked_files:

--- a/roam_to_git/fs.py
+++ b/roam_to_git/fs.py
@@ -4,6 +4,7 @@ import platform
 import zipfile
 from pathlib import Path
 from typing import Dict, List
+from subprocess import Popen, PIPE, STDOUT
 
 import git
 import pathvalidate
@@ -27,7 +28,7 @@ def reset_git_directory(git_path: Path, skip=(".git",)):
         if any(skip_item in file.parts for skip_item in skip):
             continue
         to_remove.append(file)
-    # Now we remove starting from the end to remove childs before parents
+    # Now we remove starting from the end to remove children before parents
     to_remove = sorted(set(to_remove))[::-1]
     for file in to_remove:
         if file.is_file():
@@ -39,7 +40,8 @@ def reset_git_directory(git_path: Path, skip=(".git",)):
                 file.rmdir()
 
 
-def unzip_markdown_archive(zip_dir_path: Path):
+def unzip_archive(zip_dir_path: Path):
+    logger.debug("Unzipping {}", zip_dir_path)
     zip_path = get_zip_path(zip_dir_path)
     with zipfile.ZipFile(zip_path) as zip_file:
         contents = {file.filename: zip_file.read(file.filename).decode()
@@ -48,42 +50,34 @@ def unzip_markdown_archive(zip_dir_path: Path):
     return contents
 
 
-def save_markdowns(directory: Path, contents: Dict[str, str]):
-    logger.debug("Saving markdown to {}", directory)
-    # Format and write the markdown files
+def save_files(save_format: str, directory: Path, contents: Dict[str, str]):
+    logger.debug("Saving {} to {}", save_format, directory)
     for file_name, content in contents.items():
         dest = get_clean_path(directory, file_name)
         dest.parent.mkdir(parents=True, exist_ok=True)  # Needed if a new directory is used
         # We have to specify encoding because crontab on Mac don't use UTF-8
         # https://stackoverflow.com/questions/11735363/python3-unicodeencodeerror-crontab
         with dest.open("w", encoding="utf-8") as f:
-            f.write(content)
+            if save_format == 'json':
+                json.dump(json.loads(content), f, sort_keys=True, indent=2, ensure_ascii=True)
+            else:  # markdown, formatted, edn
+                if save_format == 'edn':
+                    try:
+                        jet = Popen(
+                            ["jet", "--edn-reader-opts", "{:default tagged-literal}", "--pretty"],
+                            stdout=PIPE, stdin=PIPE, stderr=STDOUT)
+                        jet_stdout, _ = jet.communicate(input=str.encode(content))
+                        content = jet_stdout.decode()
+                    except IOError:
+                        logger.debug("Jet not installed, skipping EDN pretty printing")
 
-
-def unzip_and_save_json_archive(zip_dir_path: Path, directory: Path):
-    logger.debug("Saving json to {}", directory)
-    directory.mkdir(exist_ok=True)
-    zip_path = get_zip_path(zip_dir_path)
-    with zipfile.ZipFile(zip_path) as zip_file:
-        files = list(zip_file.namelist())
-        for file_name in files:
-            assert file_name.endswith(".json")
-            content = json.loads(zip_file.read(file_name).decode())
-            with open(directory / file_name, "w") as f:
-                json.dump(content, f, sort_keys=True, indent=2, ensure_ascii=True)
-
-
-def unzip_and_save_edn_archive(zip_dir_path: Path, directory: Path):
-    logger.debug("Saving edn to {}", directory)
-    directory.mkdir(exist_ok=True)
-    zip_path = get_zip_path(zip_dir_path)
-    with zipfile.ZipFile(zip_path) as zip_file:
-        files = list(zip_file.namelist())
-        for file in files:
-            assert file.endswith(".edn")
-            content = zip_file.read(file)
-            with open(directory / file, "wb") as f:
                 f.write(content)
+
+
+def unzip_and_save_archive(save_format: str, zip_dir_path: Path, directory: Path):
+    logger.debug("Saving {} to {}", save_format, directory)
+    contents = unzip_archive(zip_dir_path)
+    save_files(save_format, directory, contents)
 
 
 def commit_git_directory(repo: git.Repo):

--- a/roam_to_git/scrapping.py
+++ b/roam_to_git/scrapping.py
@@ -85,7 +85,7 @@ async def _download_rr_archive(document: Page,
                                ):
     """Download an archive in RoamResearch.
 
-    :param output_type: Download JSON or Markdown
+    :param output_type: Download JSON or Markdown or EDN
     :param output_directory: Directory where to stock the outputs
     """
     if not config.debug:
@@ -138,7 +138,7 @@ async def _download_rr_archive(document: Page,
         assert dropdown_button is not None
         dropdown_button_text = await get_text(document, dropdown_button)
         # Defensive check if the interface change
-        assert dropdown_button_text in ["markdown", "json"], dropdown_button_text
+        assert dropdown_button_text in ["markdown", "json", "edn"], dropdown_button_text
         return dropdown_button, dropdown_button_text
 
     logger.debug("Checking download type")
@@ -231,13 +231,15 @@ def _kill_child_process(timeout=50):
                 pass
 
 
-def scrap(markdown_zip_path: Path, json_zip_path: Path, config: Config):
+def scrap(markdown_zip_path: Path, json_zip_path: Path, edn_zip_path: Path, config: Config):
     # Just for easier run from the CLI
     markdown_zip_path = Path(markdown_zip_path)
     json_zip_path = Path(json_zip_path)
+    edn_zip_path = Path(edn_zip_path)
 
     tasks = [download_rr_archive("markdown", Path(markdown_zip_path), config=config),
              download_rr_archive("json", Path(json_zip_path), config=config),
+             download_rr_archive("edn", Path(edn_zip_path), config=config),
              ]
     # Register to always kill child process when the script close, to not have zombie process.
     # Because of https://github.com/miyakogi/pyppeteer/issues/274 without this patch it does happen

--- a/roam_to_git/scrapping.py
+++ b/roam_to_git/scrapping.py
@@ -186,7 +186,8 @@ async def signin(document, config: Config, sleep_duration=1.):
     """Sign-in into Roam"""
     logger.debug("Opening signin page")
     await document.goto('https://roamresearch.com/#/signin')
-    await asyncio.sleep(sleep_duration)
+    # increased to 5 seconds to handle sporadic second login screen refresh
+    await asyncio.sleep(6.)
 
     logger.debug("Fill email '{}'", config.user)
     email_elem = await document.querySelector("input[name='email']")


### PR DESCRIPTION
Addresses the discussion in #64

Fixes #63 

Make EDN support optional and other cleanups
* `scrapping.py`
  * Add `ROAM_FORMATS` const to define processable roam formats
  * refactor scrap to only require a tmp_dir and a list of formats to
  process
* `fs.py`
  * Simply formatting functions to a single `save_files` method that
  handles all of the different file types
  * rename `unzip_markdown_archive` --> `unzip_archive`
  * These two changes simplify `unzip_and_save_archive` which calls both
  of those two methods
  * Add optional `jet` pretty-printing and update --formats help string
* `__main__.py`
  * Add formats arg which allows the user to specify which formats they
  would like to save their files to
  * Remove skip fetch since it is now redundant
    * simply call with just `--formats formatted`
  * Simplify main execution to extend to more Roam formats if added.