### PR TITLE
Turn off geckodriver.log from being generated in Firefox driver.

### DIFF
--- a/roam_to_git/scrapping.py
+++ b/roam_to_git/scrapping.py
@@ -39,7 +39,8 @@ class Browser:
 
             logger.trace("Start Firefox")
             self.browser = webdriver.Firefox(firefox_profile=firefox_profile,
-                                             firefox_options=firefox_options)
+                                             firefox_options=firefox_options,
+                                             service_log_path=os.devnull)
         elif browser == Browser.PHANTOMJS:
             raise NotImplementedError()
             # TODO configure


### PR DESCRIPTION
As per https://github.com/MatthieuBizien/roam-to-git/commit/15bc682343873d91da1edaf2ec1194e89f290d9b#r47694402